### PR TITLE
Enhance jsc beautification

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "readmeFilename": "README.md",
-   "bugs": {
+  "bugs": {
     "url": "https://github.com/SoftwareMansion/stack-beautifier/issues"
   },
   "homepage": "https://github.com/SoftwareMansion/stack-beautifier#readme",

--- a/stack-beautifier.js
+++ b/stack-beautifier.js
@@ -49,7 +49,7 @@ if (!program.args.length) {
 }
 
 const STACK_LINE_MATCHERS = [
-  {regex: /^(.*)\@([-]?\d+)(?:\:(\d+))?$/, idx: [1, 2, 3]}, // Format: someFun@13:12
+  {regex: /^(.*)\@(?:-1|(?:(\d+)\:(\d+)))$/, idx: [1, 2, 3]}, // Format: someFun@13:12
   {regex: /^at (.*)\:(\d+)\:(\d+)$/, idx: [1, 2, 3]}, // Format: at filename:13:12
   {regex: /^at (.*) \((.*)\:(\d+)\:(\d+)\)$/, idx: [1, 3, 4]}, // Format: at someFun (filename:13:12)
   {regex: /^at (.*)\:(\d+)$/, idx: [1, 2, 3]} // Format: at filename:13


### PR DESCRIPTION
An attempt ad addressing #2 , and also dealing with JSC stack trace entries with a '-1' line number. 

I'm open to suggestions.

For example:

```
TypeError: undefined is not an object (evaluating 'Object.keys(t[n])')

This error is located at:
    in C
    in RCTView
    in p
    in _
    in p
    in RCTView
    in RCTView
    in RCTView
    in u
    in RCTView
    in u
    in C
    in n
    in E
    in RCTView
    in n
    in RCTView
    in u
    in PanGestureHandler
    in n
    in L
    in RCTView
    in n
    in t
    in P
    in v
    in p
    in RCTView
    in RCTView
    in l
    in RCTView
    in n
    in RCTView
    in u
    in RCTView
    in u
    in PanGestureHandler
    in n
    in S
    in P
    in P
    in _
    in s
    in n
    in h
    in RCTView
    in RCTView
    in c, stack:
keys@-1
<unknown>@290:1418
forEach@-1
value@290:1373
C@1512:523
Sn@90:30120
Or@90:45887
na@90:72881
ra@90:73371
Oa@90:80972
Wa@90:80310
Ue@90:83367
De@90:13673
notify@596:871
notifyNestedSubs@596:443
notifySubscribers@593:1112
<unknown>@-1
handleChangeWrapper@596:518
<unknown>@-1
j@605:4370
<unknown>@957:9704
<unknown>@1067:741
onPress@1541:1667
<unknown>@144:2232
value@28:3600
<unknown>@28:1144
value@28:2565
value@28:1114
value@-1

```